### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,6 +3,7 @@ author=Matthijs Kooijman
 email=matthijs@stdin.nl
 sentence=Library for Gainspan Serial-to-wifi modules.
 paragraph=This library allows using these module to send and receive data through TCP, UDP, SSL, etc.
+category=Communication
 url=https://github.com/Pinoccio/library-gainspan-s2w
 architectures=*
 version=0.1


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library GainspanS2W is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6 and 1.6.7. If you prefer a different category I'm happy to change it to any of the other [valid category values](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification) and squash to a single commit.
